### PR TITLE
For COMPATIBILITY with IE11（兼容ie11）

### DIFF
--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.ts
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.ts
@@ -22,7 +22,7 @@ export class NgxSkeletonLoaderComponent implements OnInit {
   ngOnInit() {
     this.items.length = this.count;
     const allowedAnimations = ['progress', 'progress-dark', 'pulse', 'false'];
-    if (!allowedAnimations.includes(this.animation)) {
+    if (allowedAnimations.indexOf(this.animation)===-1) {
       // Shows error message only in Development
       if (isDevMode()) {
         console.error(


### PR DESCRIPTION
Since IE11 is not compatible with includes methods, there will be an ERROR 'IE11 ERROR TypeError: the object does not support the "includes" property or methods, so use indexOf instead to bring better compatibility and scope.