### PR TITLE
Fix perfs_hooks calls when rendering server side

### DIFF
--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.spec.ts
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.spec.ts
@@ -1,5 +1,6 @@
-import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
+import { Component, NO_ERRORS_SCHEMA, PLATFORM_ID } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
+import * as perfMarks from 'perf-marks/marks';
 
 import { NgxSkeletonLoaderComponent } from './ngx-skeleton-loader.component';
 
@@ -58,6 +59,7 @@ describe('NgxSkeletonLoaderComponent', () => {
     spyOn(console, 'error');
     fixture = TestBed.configureTestingModule({
       declarations: [ContainerComponent, NgxSkeletonLoaderComponent],
+      providers: [{ provide: PLATFORM_ID, useValue: 'browser'}],
       schemas: [NO_ERRORS_SCHEMA],
     }).createComponent(ContainerComponent);
     fixture.detectChanges();
@@ -178,6 +180,20 @@ describe('NgxSkeletonLoaderComponent', () => {
       expect(skeletonWithTheming.getNamedItem('style').value).toBe(
         'width: 70px; height: 70px; border-radius: 10px;'
       );
+    });
+  });
+
+  describe('When rendering server side', () => {
+    it('should not call perf-marks functions', () => {
+      const spyStart = jasmine.createSpy('start', perfMarks.start);
+      const spyEnd = jasmine.createSpy('start', perfMarks.end);
+
+
+      const ngxSkeletonLoaderComponent = TestBed.createComponent<NgxSkeletonLoaderComponent>(NgxSkeletonLoaderComponent).componentInstance;
+      spyOn<NgxSkeletonLoaderComponent, 'isBrowser'>(ngxSkeletonLoaderComponent, 'isBrowser').and.returnValue(false);
+
+      expect(spyStart).not.toHaveBeenCalled();
+      expect(spyEnd).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.ts
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, Input, isDevMode, OnDestroy, AfterViewInit } from '@angular/core';
+import { Component, OnInit, Input, isDevMode, OnDestroy, AfterViewInit, Inject, PLATFORM_ID } from '@angular/core';
 import { start, end } from 'perf-marks/marks';
+import { isPlatformBrowser } from '@angular/common';
 
 @Component({
   selector: 'ngx-skeleton-loader',
@@ -20,9 +21,14 @@ export class NgxSkeletonLoaderComponent implements OnInit, AfterViewInit, OnDest
 
   items: Array<any> = [];
 
+  constructor(@Inject(PLATFORM_ID) private readonly platformId: any) {
+  }
+
   ngOnInit() {
-    start('NgxSkeletonLoader:Rendered');
-    start('NgxSkeletonLoader:Loaded');
+    if (this.isBrowser()) {
+      start('NgxSkeletonLoader:Rendered');
+      start('NgxSkeletonLoader:Loaded');
+    }
 
     this.items.length = this.count;
     const allowedAnimations = ['progress', 'progress-dark', 'pulse', 'false'];
@@ -40,10 +46,18 @@ export class NgxSkeletonLoaderComponent implements OnInit, AfterViewInit, OnDest
   }
 
   ngAfterViewInit() {
-    end('NgxSkeletonLoader:Rendered');
+    if (this.isBrowser()) {
+      end('NgxSkeletonLoader:Rendered');
+    }
   }
 
   ngOnDestroy() {
-    end('NgxSkeletonLoader:Loaded');
+    if (this.isBrowser()) {
+      end('NgxSkeletonLoader:Loaded');
+    }
+  }
+
+  isBrowser(): boolean {
+    return isPlatformBrowser(this.platformId);
   }
 }


### PR DESCRIPTION
… component is rendered in a browser

**Please check if the PR fulfills these requirements**

- [ ] The commit messages follow these
      [guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** _(check one with "x")_

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other. Please describe:

If it is a Bugfix, please describe the root cause and what could have been done to prevent it…

**What is the current behavior?** _(You can link to an open issue here, add screenshots…)_

Using NgUniversal v9, the SSR application can't start because of perf-marks.

`Error: Your NodeJS application doesn't support 'perf_hooks'. TypeError: mod.require is not a function`

**What is the new behavior?**

The component doesn't call for perf-marks functions anymore when the component is rendered server-side.

**Does this PR introduce a breaking change?** _(check one with "x")_

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: …

**Other information (if applicable)**:

---

_Please @mention @people to review this PR…_
