### PR TITLE
refactor: rename generic loader class name to be more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ You can apply theme changes in our stylesheet. At the end it will be
  * You can find more details about `:host` at
  * Angular Component Style Docs https://angular.io/guide/component-styles#host
  */
-:host >>> ngx-skeleton-loader .loader {
+:host >>> ngx-skeleton-loader .skeleton-loader {
   border-radius: 5px;
   height: 50px;
   background-color: #992929;

--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.spec.ts
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.spec.ts
@@ -126,12 +126,12 @@ describe('NgxSkeletonLoaderComponent', () => {
     });
 
     it('should use progress as default animation if `animation` is not passed as component attribute', () => {
-      expect(fixture.nativeElement.querySelectorAll('.skeletons-defaults .loader.progress').length).toBe(1);
+      expect(fixture.nativeElement.querySelectorAll('.skeletons-defaults .skeleton-loader.progress').length).toBe(1);
     });
 
     describe('When skeleton is created using default settings', () => {
       it('should render a single skeleton', () => {
-        expect(fixture.nativeElement.querySelectorAll('.skeletons-defaults .loader').length).toBe(1);
+        expect(fixture.nativeElement.querySelectorAll('.skeletons-defaults .skeleton-loader').length).toBe(1);
       });
     });
 
@@ -143,27 +143,27 @@ describe('NgxSkeletonLoaderComponent', () => {
 
     describe('When skeleton is created with count', () => {
       it('should render skeleton based on given count attribute', () => {
-        expect(fixture.nativeElement.querySelectorAll('.skeletons-with-count .loader').length).toBe(2);
+        expect(fixture.nativeElement.querySelectorAll('.skeletons-with-count .skeleton-loader').length).toBe(2);
       });
     });
 
     describe('When skeleton is created with circle appearance', () => {
       it('should add styles based on circle class on the skeleton components', () => {
-        expect(fixture.nativeElement.querySelectorAll('.skeletons-appearance-circle .loader.circle').length).toBe(1);
+        expect(fixture.nativeElement.querySelectorAll('.skeletons-appearance-circle .skeleton-loader.circle').length).toBe(1);
       });
     });
 
     describe('When skeleton is created without animation', () => {
       it('should NOT add progress animation styles based on animation class on the skeleton components', () => {
         expect(
-          fixture.nativeElement.querySelectorAll('.skeletons-animation-no-animation .loader:not(.animation)').length,
+          fixture.nativeElement.querySelectorAll('.skeletons-animation-no-animation .skeleton-loader:not(.animation)').length,
         ).toBe(1);
       });
 
       it('should NOT add progress animation styles based on animation class if animation value is passed via binding', () => {
         expect(
           fixture.nativeElement.querySelectorAll(
-            '.skeletons-animation-no-animation-via-binding .loader:not(.animation)',
+            '.skeletons-animation-no-animation-via-binding .skeleton-loader:not(.animation)',
           ).length,
         ).toBe(1);
       });
@@ -171,27 +171,27 @@ describe('NgxSkeletonLoaderComponent', () => {
 
     describe('When skeleton is created using `pulse` as animation', () => {
       it('should add pulse animation styles based on animation class on the skeleton components', () => {
-        expect(fixture.nativeElement.querySelectorAll('.skeletons-animation-pulse .loader.pulse').length).toBe(1);
+        expect(fixture.nativeElement.querySelectorAll('.skeletons-animation-pulse .skeleton-loader.pulse').length).toBe(1);
       });
     });
 
     describe('When skeleton is created using `progress-dark` as animation', () => {
       it('should add progress-dark animation styles based on animation class on the skeleton components', () => {
         expect(
-          fixture.nativeElement.querySelectorAll('.skeletons-animation-progress-dark .loader.progress-dark').length,
+          fixture.nativeElement.querySelectorAll('.skeletons-animation-progress-dark .skeleton-loader.progress-dark').length,
         ).toBe(1);
       });
     });
 
     describe('When skeleton is created using `progress` as animation', () => {
       it('should add progress animation styles based on animation class on the skeleton components', () => {
-        expect(fixture.nativeElement.querySelectorAll('.skeletons-animation-progress .loader.progress').length).toBe(1);
+        expect(fixture.nativeElement.querySelectorAll('.skeletons-animation-progress .skeleton-loader.progress').length).toBe(1);
       });
     });
 
     describe('When skeleton is created with theming', () => {
       it('should render skeleton with styles based on theme attribute', () => {
-        const skeletonWithTheming = fixture.nativeElement.querySelector('.skeletons-with-theming .loader.circle')
+        const skeletonWithTheming = fixture.nativeElement.querySelector('.skeletons-with-theming .skeleton-loader.circle')
           .attributes as NamedNodeMap;
 
         expect((skeletonWithTheming.getNamedItem('style') as Attr).value).toBe(
@@ -216,7 +216,7 @@ describe('NgxSkeletonLoaderComponent', () => {
     );
 
     it('should render skeleton with the provided config', () => {
-      expect(fixture.nativeElement.querySelectorAll('.skeletons-with-provided-config .loader.circle').length).toBe(3);
+      expect(fixture.nativeElement.querySelectorAll('.skeletons-with-provided-config .skeleton-loader.circle').length).toBe(3);
     });
   });
 });

--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.html
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.html
@@ -1,6 +1,6 @@
 <span
   *ngFor="let item of items"
-  class="loader"
+  class="skeleton-loader"
   [attr.aria-label]="ariaLabel"
   aria-busy="true"
   aria-valuemin="0"

--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.module.spec.ts
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.module.spec.ts
@@ -35,7 +35,7 @@ describe('NgxSkeletonLoaderModule method', () => {
   );
 
   it('should render the component properly using given forRoot() config', () => {
-    expect(fixture.nativeElement.querySelectorAll('.skeletons-defaults .loader.circle').length).toBe(3);
+    expect(fixture.nativeElement.querySelectorAll('.skeletons-defaults .skeleton-loader.circle').length).toBe(3);
   });
 
   it('should NOT call console.error() method', () => {

--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.scss
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.scss
@@ -1,4 +1,4 @@
-.loader {
+.skeleton-loader {
   box-sizing: border-box;
 
   /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit messages follow these
      [guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** _(check one with "x")_

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other. Please describe:

**Does this PR introduce a breaking change?** _(check one with "x")_

- [x] Yes
- [ ] No

In the readme, there are instructions on applying custom themes from a stylesheet. Here the class ```.loader``` is explicitly mentioned. If someone has followed these instructions, their custom styling will no longer work after this pull request is merged. However, I still decided to submit this pull request, because a warning mentions '...it's not encouraged to be used' and '...It means that class naming changes on module's side will be breaking changes for your application as well'. 

**Other information (if applicable)**:

In our project, we are very happy with this the ```ngx-skeleton-loader``` library. However, another library we use - [@formio/angular](https://www.npmjs.com/package/@formio/angular) - loads global styling on the ```.loader``` class name, and this sometimes conflicts with ```ngx-skeleton-loader```, causing graphical glitches. After these changes, this conflict will be solved, and it also avoids future styling conflicts for other projects, as the class name ```.loader``` is likely to be used elsewhere.

@willmendesneto 
