### PR TITLE
fix: Disable focus on skeleton

### DIFF
--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.spec.ts
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.spec.ts
@@ -136,7 +136,7 @@ describe('NgxSkeletonLoaderComponent', () => {
       expect(fixture.nativeElement.querySelectorAll('[aria-valuemax="100"]').length).toBe(16);
       expect(fixture.nativeElement.querySelectorAll('[aria-valuetext]').length).toBe(16);
       expect(fixture.nativeElement.querySelectorAll('[role="progressbar"]').length).toBe(16);
-      expect(fixture.nativeElement.querySelectorAll('[tabindex="0"]').length).toBe(16);
+      expect(fixture.nativeElement.querySelectorAll('[tabindex="-1"]').length).toBe(16);
       expect(fixture.nativeElement.querySelectorAll('[aria-label="loading"]').length).toBe(16);
     });
 

--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.html
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.html
@@ -7,7 +7,7 @@
   aria-valuemax="100"
   [attr.aria-valuetext]="loadingText"
   role="progressbar"
-  tabindex="0"
+  tabindex="-1"
   [ngClass]="{
     'custom-content': appearance === 'custom-content',
     circle: appearance === 'circle',


### PR DESCRIPTION
With tabindex set to 0, the skeleton receives focus sometimes.  I am able to navigate to the skeletons with tab, while the page is loading, and there is an outline on the navigated line. Tabindex -1 prevents the element to be in focus.

**Please check if the PR fulfills these requirements**

- [x] The commit messages follow these
      [guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** _(check one with "x")_

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other. Please describe:

If it is a Bugfix, please describe the root cause and what could have been done to prevent it…

**What is the current behavior?** _(You can link to an open issue here, add screenshots…)_

**What is the new behavior?**

**Does this PR introduce a breaking change?** _(check one with "x")_

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: …

**Other information (if applicable)**:

---

_Please @mention @people to review this PR…_
