### PR TITLE
refactor: remove `[ngStyle]` and `[ngClass]`

### DIFF
--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.spec.ts
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.spec.ts
@@ -202,9 +202,8 @@ describe('NgxSkeletonLoaderComponent', () => {
           '.skeletons-with-theming .skeleton-loader.circle',
         ).attributes as NamedNodeMap;
 
-        expect((skeletonWithTheming.getNamedItem('style') as Attr).value).toBe(
-          'width: 70px; height: 70px; border-radius: 10px;',
-        );
+        const style = (skeletonWithTheming.getNamedItem('style') as Attr).value;
+        expect(style).toEqual('border-radius: 10px; height: 70px; width: 70px;');
       });
     });
   });

--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.ts
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.component.ts
@@ -7,7 +7,6 @@ import {
   numberAttribute,
   computed,
 } from '@angular/core';
-import { NgClass, NgStyle } from '@angular/common';
 import {
   NgxSkeletonLoaderConfig,
   NgxSkeletonLoaderConfigTheme,
@@ -25,7 +24,6 @@ import {
   selector: 'ngx-skeleton-loader',
   templateUrl: './ngx-skeleton-loader.html',
   styleUrls: ['./ngx-skeleton-loader.scss'],
-  imports: [NgClass, NgStyle],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })

--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.html
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.html
@@ -10,14 +10,12 @@
     [attr.aria-valuetext]="loadingText()"
     role="progressbar"
     tabindex="-1"
-    [ngClass]="{
-      'custom-content': appearanceValue === 'custom-content',
-      circle: appearanceValue === 'circle',
-      progress: animationValue === 'progress',
-      'progress-dark': animationValue === 'progress-dark',
-      pulse: animationValue === 'pulse'
-    }"
-    [ngStyle]="styles()"
+    [class.custom-content]="appearanceValue === 'custom-content'"
+    [class.circle]="appearanceValue === 'circle'"
+    [class.progress]="animationValue === 'progress'"
+    [class.progress-dark]="animationValue === 'progress-dark'"
+    [class.pulse]="animationValue === 'pulse'"
+    [style]="styles()"
     >
     @if (appearanceValue  === 'custom-content') {
       <ng-content></ng-content>

--- a/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.module.ts
+++ b/projects/ngx-skeleton-loader/src/lib/ngx-skeleton-loader.module.ts
@@ -1,11 +1,10 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 
 import { NgxSkeletonLoaderComponent } from './ngx-skeleton-loader.component';
 import { NgxSkeletonLoaderConfig, NGX_SKELETON_LOADER_CONFIG } from './ngx-skeleton-loader-config.types';
 
 @NgModule({
-  imports: [CommonModule, NgxSkeletonLoaderComponent],
+  imports: [NgxSkeletonLoaderComponent],
   exports: [NgxSkeletonLoaderComponent],
 })
 export class NgxSkeletonLoaderModule {


### PR DESCRIPTION
This removes the `NgClass` and `NgStyle` directives, as they are redundant. These directives are expected to be removed in future Angular versions, since their behavior can be replicated using native bindings. This change also reduces the initial bundle size for applications that don’t use these directives.